### PR TITLE
Altered the Landing page and Added Two new pages

### DIFF
--- a/adminlogin.html
+++ b/adminlogin.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Administrator Login Page</title>
+    </head>
+
+    <body>
+        <script src="https://accounts.google.com/gsi/client" async defer></script>
+        <div id="g_id_onload"
+             data-client_id="911436566286-36r6uc7oavbrmqcmn7b2ijo3q34mn1gi.apps.googleusercontent.com"
+             data-context="signin"
+             data-ux_mode="popup"
+             data-login_uri="https://ceias.nau.edu/capstone/projects/CS/2022/WhatsUpDoc_S22/C&I_Doctoral_Tracker/admin.html?"
+             data-itp_support="true">
+        </div>
+
+    <p>ADMINISTRATORS! Click the Google Sign-In Button Below:</p>
+
+    <div class="g_id_signin"
+         data-type="standard"
+         data-shape="pill"
+         data-theme="filled_black"
+         data-text="signin_with"
+         data-size="large"
+         data-locale="en-US"
+         data-logo_alignment="left"
+         data-width="250">
+    </div>
+    </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+  <title>Landing Page</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+<div class="loginWindow">
+  
+  <form action="https://ceias.nau.edu/capstone/projects/CS/2022/WhatsUpDoc_S22/studentlogin.html?">
+    <input type="submit" value="Click Here for Student Login Page" />
+  </form>
+
+  <form action="https://ceias.nau.edu/capstone/projects/CS/2022/WhatsUpDoc_S22/adminlogin.html?">
+    <input type="submit" value="Click Here for Administrator Login Page" />
+  </form>
+
+  <form action="https://ceias.nau.edu/capstone/projects/CS/2022/WhatsUpDoc_S22/index.html">
+    <input type="submit" value="Return to Group Page" />
+  </form>
+</div>
+</body>
+
+</html>

--- a/studentlogin.html
+++ b/studentlogin.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Student Login Page</title>
+    </head>
+
+    <body>
+        <script src="https://accounts.google.com/gsi/client" async defer></script>
+        <div id="g_id_onload"
+             data-client_id="911436566286-36r6uc7oavbrmqcmn7b2ijo3q34mn1gi.apps.googleusercontent.com"
+             data-context="signin"
+             data-ux_mode="popup"
+             data-login_uri="https://ceias.nau.edu/capstone/projects/CS/2022/WhatsUpDoc_S22/C&I_Doctoral_Tracker/home.html?"
+             data-itp_support="true">
+        </div>
+
+    <p>STUDENTS! Click the Google Sign-In Button Below:</p>
+
+    <div class="g_id_signin"
+         data-type="standard"
+         data-shape="pill"
+         data-theme="filled_blue"
+         data-text="signin_with"
+         data-size="large"
+         data-locale="en-US"
+         data-logo_alignment="left"
+         data-width="250">
+    </div>
+    </body>
+</html>


### PR DESCRIPTION
I'm altering the landing page (index.html) to prompt the user to click on a button submission to indicate whether they are logging in as a student or as an admin. There is no security check *as of this commit* further than requiring an @nau.edu email. This will allow us to properly redirect to the student home page or the admin home page based on the login page the user is using. Once we being implementing the TokenID and checking the authorized email associated with the gmail account, then we will be able to distinguish between a student and an admin with a single Google Sign-In button and one landing page/login page.